### PR TITLE
fix: color names in Spanish translation

### DIFF
--- a/dist/locales/bootstrap-wysihtml5.es-ES.js
+++ b/dist/locales/bootstrap-wysihtml5.es-ES.js
@@ -46,16 +46,16 @@
         },
         colours: {
           black: "Negro",
-          silver: "Plata",
+          silver: "Plateado",
           gray: "Gris",
           maroon: "Marrón",
           red: "Rojo",
-          purple: "Púrpura",
+          purple: "Morado",
           green: "Verde",
           olive: "Oliva",
           navy: "Azul Marino",
           blue: "Azul",
-          orange: "Naranja"
+          orange: "Anaranjado"
         }
     };
 }));


### PR DESCRIPTION
Colors are adjectives, so fixed nouns: 'plata', 'naranja' | 'morado' is a preferred translation of 'purple'.
