### PR TITLE
Updating package.json to point to this repo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/Waxolunist/bootstrap3-wysihtml5-bower.git"
+    "url": "git://github.com/bootstrap-wysiwyg/bootstrap3-wysiwyg.git"
   },
   "keywords": [
     "bootstrap",
@@ -41,7 +41,7 @@
   "author": "Christian Sterzl <christian.sterzl@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Waxolunist/bootstrap3-wysihtml5-bower/issues"
+    "url": "https://github.com/bootstrap-wysiwyg/bootstrap3-wysiwyg/issues"
   },
-  "homepage": "https://github.com/Waxolunist/bootstrap3-wysihtml5-bower"
+  "homepage": "https://github.com/bootstrap-wysiwyg/bootstrap3-wysiwyg"
 }


### PR DESCRIPTION
The Waxolunist repo has a notice stating that they are deprecated in favor of this repo, but the bower package still points back to the old repo. Any reason for this?